### PR TITLE
Feat: Add health check support.

### DIFF
--- a/src-nextjs/lib/healthchecks/drupal.ts
+++ b/src-nextjs/lib/healthchecks/drupal.ts
@@ -1,0 +1,25 @@
+import * as DrupalClient from "../drupal"
+import { HealthCheck } from "./healthcheck"
+
+
+class DrupalHealthCheck implements HealthCheck {
+  async startup() : Promise<boolean> {
+    let status = true
+    try {
+      DrupalClient.drupal.getResourceByPath("/")
+    } catch (error) {
+      status = false
+    }
+    return new Promise(resolve => resolve(status))
+  }
+  async ready() : Promise<boolean> {
+    let status = true
+    return new Promise(resolve => resolve(status))
+  }  
+  async alive() : Promise<boolean> {
+    let status = true
+    return new Promise(resolve => resolve(status))
+  }
+}
+
+export const drupal = new DrupalHealthCheck()

--- a/src-nextjs/lib/healthchecks/healthcheck.ts
+++ b/src-nextjs/lib/healthchecks/healthcheck.ts
@@ -1,0 +1,5 @@
+export interface HealthCheck {
+  startup(): Promise<boolean>
+  ready(): Promise<boolean>
+  alive(): Promise<boolean>
+}

--- a/src-nextjs/lib/healthchecks/index.ts
+++ b/src-nextjs/lib/healthchecks/index.ts
@@ -1,0 +1,1 @@
+export * from "./drupal"

--- a/src-nextjs/pages/.well-known/liveness.tsx
+++ b/src-nextjs/pages/.well-known/liveness.tsx
@@ -1,0 +1,26 @@
+import * as healthchecks from "../../lib/healthchecks"
+
+export default function Healthz() {
+  return (<></>);
+}
+
+export const getServerSideProps = async ({ req, res, resolvedUrl }) => {
+  const data = {status: "success", checks: {}}
+  let status = 200
+
+  for (const healthcheck in healthchecks) {
+    data.checks[healthcheck] = await healthchecks[healthcheck].alive()
+    if (data.checks[healthcheck] === false) {
+      status = 400
+    }
+  }
+
+  res.setHeader("Content-Type", "application/json");
+  res.statusCode = status
+  res.write(JSON.stringify(data));
+  res.end();
+  
+  return {
+      props: {},
+  };
+}

--- a/src-nextjs/pages/.well-known/ready.tsx
+++ b/src-nextjs/pages/.well-known/ready.tsx
@@ -1,0 +1,26 @@
+import * as healthchecks from "../../lib/healthchecks"
+
+export default function Healthz() {
+  return (<></>);
+}
+
+export const getServerSideProps = async ({ req, res, resolvedUrl }) => {
+  const data = {status: "success", checks: {}}
+  let status = 200
+
+  for (const healthcheck in healthchecks) {
+    data.checks[healthcheck] = await healthchecks[healthcheck].ready()
+    if (data.checks[healthcheck] === false) {
+      status = 400
+    }
+  }
+
+  res.setHeader("Content-Type", "application/json");
+  res.statusCode = status
+  res.write(JSON.stringify(data));
+  res.end();
+  
+  return {
+      props: {},
+  };
+}

--- a/src-nextjs/pages/.well-known/startup.tsx
+++ b/src-nextjs/pages/.well-known/startup.tsx
@@ -1,0 +1,26 @@
+import * as healthchecks from "../../lib/healthchecks"
+
+export default function Healthz() {
+  return (<></>);
+}
+
+export const getServerSideProps = async ({ req, res, resolvedUrl }) => {
+  const data = {status: "success", checks: {}}
+  let status = 200
+
+  for (const healthcheck in healthchecks) {
+    data.checks[healthcheck] = await healthchecks[healthcheck].startup()
+    if (data.checks[healthcheck] === false) {
+      status = 400
+    }
+  }
+
+  res.setHeader("Content-Type", "application/json");
+  res.statusCode = status
+  res.write(JSON.stringify(data));
+  res.end();
+  
+  return {
+      props: {},
+  };
+}

--- a/src-nextjs/tsconfig.json
+++ b/src-nextjs/tsconfig.json
@@ -16,6 +16,6 @@
     "baseUrl": "./",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "pages/.well-known/_healthz.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- Adds `/.well-known/startup` to determine that the node app is ready to accept connections and can connect to Drupal correctly
- Adds `/.well-known/ready` to perform periodic checks that determine if the application is ready to handle requests
- Adds `/.well-known/liveness` to perform checks to validate the applications is still alive

These require changes to the helm charts (updates to the probe definitions) to support accepting these.