### PR TITLE
Add nextjs container to ddev startup

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -13,7 +13,6 @@ use_dns_when_possible: true
 composer_version: "2"
 web_environment:
     - QUANT_ENVIRONMENT_TYPE=local
-nodejs_version: "18"
 
 composer_root: src-drupal
 

--- a/.ddev/docker-compose.nextjs.yaml
+++ b/.ddev/docker-compose.nextjs.yaml
@@ -6,17 +6,29 @@ services:
     build:
       context: ../
       dockerfile: Dockerfile-nextjs
+    command: sh -c "npm run build && npm run dev"
     depends_on:
       - web
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.platform: ddev
       com.ddev.app-type: nextjs
-      com.ddev.approot: $DDEV_APPROOT
     environment:
+      NODE_ENV: development
       NEXT_PUBLIC_DRUPAL_BASE_URL: http://web
       NEXT_PUBLIC_IMAGE_DOMAIN: http://web
       NEXT_PUBLIC_BASE_URL: http://web
       VIRTUAL_HOST: $DDEV_HOSTNAME
       HTTP_EXPOSE: 9998:3000
       HTTPS_EXPOSE: 9999:3000
+    volumes:
+      - ../src-nextjs/tsconfig.json:/app/tsconfig.json
+      - ../src-nextjs/tailwind.config.js:/app/tailwind.config.js
+      - ../src-nextjs/styles:/app/styles
+      - ../src-nextjs/postcss.config.js:/app/postcss.config.js
+      - ../src-nextjs/lib:/app/lib
+      - ../src-nextjs/components:/app/components
+      - ../src-nextjs/pages:/app/pages
+      - ../src-nextjs/public:/app/public
+      - ../src-nextjs/next-env.d.ts:/app/next-env.d.ts
+      - ../src-nextjs/next.config.js:/app/next.config.js

--- a/.ddev/docker-compose.nextjs.yaml
+++ b/.ddev/docker-compose.nextjs.yaml
@@ -17,9 +17,6 @@ services:
       NEXT_PUBLIC_DRUPAL_BASE_URL: http://web
       NEXT_PUBLIC_IMAGE_DOMAIN: http://web
       NEXT_PUBLIC_BASE_URL: http://web
-      # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
-      # To expose a container port to a different host port, define the port as hostPort:containerPort
+      VIRTUAL_HOST: $DDEV_HOSTNAME
       HTTP_EXPOSE: 9998:3000
-      # You can optionally expose an HTTPS port option for any ports defined in HTTP_EXPOSE.
-      # To expose an HTTPS port, define the port as securePort:containerPort.
       HTTPS_EXPOSE: 9999:3000

--- a/.ddev/docker-compose.nextjs.yaml
+++ b/.ddev/docker-compose.nextjs.yaml
@@ -1,0 +1,25 @@
+version: '3.6' 
+services:
+  nextjs:
+    container_name: ddev-${DDEV_SITENAME}-nextjs
+    restart: always
+    build:
+      context: ../
+      dockerfile: Dockerfile-nextjs
+    depends_on:
+      - web
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.platform: ddev
+      com.ddev.app-type: nextjs
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      NEXT_PUBLIC_DRUPAL_BASE_URL: http://web
+      NEXT_PUBLIC_IMAGE_DOMAIN: http://web
+      NEXT_PUBLIC_BASE_URL: http://web
+      # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
+      # To expose a container port to a different host port, define the port as hostPort:containerPort
+      HTTP_EXPOSE: 9998:3000
+      # You can optionally expose an HTTPS port option for any ports defined in HTTP_EXPOSE.
+      # To expose an HTTPS port, define the port as securePort:containerPort.
+      HTTPS_EXPOSE: 9999:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ x-environment: &environment
     APACHE_RUN_USER: nobody
     DRUPAL_REVALIDATE_SECRET: secret
     DRUPAL_PREVIEW_SECRET: secret
+    NODE_ENV: development
     NEXT_PUBLIC_DRUPAL_BASE_URL: "http://drupal"
     NEXT_PUBLIC_IMAGE_DOMAIN: "http://localhost:81"
     REDIS_HOST: redis
@@ -33,22 +34,23 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile-nextjs
+    command: sh -c "npm run build && npm run dev"
     depends_on:
       - drupal
     <<: *environment
     ports:
       - "80:3000"
     volumes:
-    - ./src-nextjs/tsconfig.json:/app/tsconfig.json
-    - ./src-nextjs/tailwind.config.js:/app/tailwind.config.js
-    - ./src-nextjs/styles:/app/styles
-    - ./src-nextjs/postcss.config.js:/app/postcss.config.js
-    - ./src-nextjs/lib:/app/lib
-    - ./src-nextjs/components:/app/components
-    - ./src-nextjs/pages:/app/pages
-    - ./src-nextjs/public:/app/public
-    - ./src-nextjs/next-env.d.ts:/app/next-env.d.ts
-    - ./src-nextjs/next.config.js:/app/next.config.js
+      - ./src-nextjs/tsconfig.json:/app/tsconfig.json
+      - ./src-nextjs/tailwind.config.js:/app/tailwind.config.js
+      - ./src-nextjs/styles:/app/styles
+      - ./src-nextjs/postcss.config.js:/app/postcss.config.js
+      - ./src-nextjs/lib:/app/lib
+      - ./src-nextjs/components:/app/components
+      - ./src-nextjs/pages:/app/pages
+      - ./src-nextjs/public:/app/public
+      - ./src-nextjs/next-env.d.ts:/app/next-env.d.ts
+      - ./src-nextjs/next.config.js:/app/next.config.js
 
   mariadb:
     image: mariadb:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.6'
 
 x-environment: &environment
   environment:


### PR DESCRIPTION
* will use same Dockerfile as used for the cloud build
* will restart container if unhealthy (e.g Drupal is not ready)
* will be available on `https://app-drupal-nextjs.ddev.site:9999`

Ideally we could include the additional container URL in the startup message (e.g during `ddev start`). At the moment you can see it via `ddev status`